### PR TITLE
Feature/llamacpp handler unit tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+name: Go CI
+on:
+  push:
+    branches:
+      - main
+      - 'feature/*'
+  pull_request:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '^1.22'
+    - name: Install dependencies
+      run: go mod download
+    - name: Run tests
+      run: go test ./...
+      env:
+        GOFLAGS: -mod=readonly

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,12 @@
 module github.com/discovertomorrow/progai-middleware
 
 go 1.22.0
+
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/llamacpp/backend.go
+++ b/pkg/llamacpp/backend.go
@@ -10,6 +10,8 @@ import (
 	"github.com/discovertomorrow/progai-middleware/pkg/logging"
 )
 
+type handleFunc func(ctx context.Context, slot Slot, req Request, writeLine func(line []byte) bool, lineByLine bool) error
+
 func handleLlamacpp(
 	ctx context.Context,
 	slot Slot,

--- a/pkg/llamacpp/handle_test.go
+++ b/pkg/llamacpp/handle_test.go
@@ -1,0 +1,157 @@
+package llamacpp
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/discovertomorrow/progai-middleware/pkg/handler"
+	"github.com/stretchr/testify/mock"
+)
+
+// Mock function type
+type MockHandleFunc struct {
+	mock.Mock
+}
+
+func (m *MockHandleFunc) Handle(
+	ctx context.Context,
+	slot Slot,
+	req Request,
+	writeLine func(line []byte) bool,
+	lineByLine bool,
+) error {
+	args := m.Called(ctx, slot, req, writeLine, lineByLine)
+	return args.Error(0)
+}
+
+// Setup function to initialize common objects
+func setup() (*MockHandleFunc, []handler.Endpoint) {
+	mockHandle := new(MockHandleFunc)
+	mockHandle.On(
+		"Handle",
+		mock.Anything,
+		mock.MatchedBy(func(slot Slot) bool {
+			return slot.endpointSlot.endpoint == "http://localhost:8080"
+		}),
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(nil)
+
+	endpoints := []handler.Endpoint{
+		{Endpoint: "http://localhost:8080", Parallel: 1},
+	}
+
+	return mockHandle, endpoints
+}
+
+func TestNewLlamacppHandler(t *testing.T) {
+	mockHandle, endpoints := setup()
+
+	handler := newLlamacppHandlerInternal(
+		true,
+		mockHandle.Handle,
+		NewQueue(endpoints),
+	)
+
+	// Test case where prompt is provided
+	t.Run("WithPrompt", func(t *testing.T) {
+		reqBody := `{"prompt": "Hi"}`
+		req := httptest.NewRequest("POST", "/", strings.NewReader(reqBody))
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status OK; got %v", resp.Status)
+		}
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	// Test case where prompt is missing
+	t.Run("WithoutPrompt", func(t *testing.T) {
+		reqBody := `{}` // Missing prompt
+		req := httptest.NewRequest("POST", "/", strings.NewReader(reqBody))
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected status 400; got %v", resp.Status)
+		}
+	})
+}
+
+func TestNewLlamacppChatHandler(t *testing.T) {
+	chatTemplate := `{{ range . }}
+{{- if eq .Role "system" }} [INST] <system> {{ .Content }} </system> [/INST]
+{{- else if eq .Role "user" }} [INST] {{ .Content }} [/INST]
+{{- else if eq .Role "tool" }} [INST] <toolresult> {{ .Content }} </toolresult> [/INST]
+{{- else }} {{ .Content }}
+{{- if .ToolCalls }}{{ range .ToolCalls }}<toolcall> {{ .Function.Name }} with arguments {{ .Function.Arguments }} </toolcall> {{ end }}{{ end -}}
+</s>{{ end }}
+{{- end }}`
+	stop := []string{"</s>"}
+	mockHandle, endpoints := setup()
+
+	handler := newLlamacppChatHandlerInternal(
+		slog.Default(),
+		true,
+		chatTemplate,
+		stop,
+		mockHandle.Handle,
+		NewQueue(endpoints),
+	)
+
+	// Test case where prompt is provided
+	t.Run("WithPrompt", func(t *testing.T) {
+		reqBody := `{
+  "model": "gpt-4o",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a helpful assistant."
+    },
+    {
+      "role": "user",
+      "content": "Hello!"
+    }
+  ]
+}`
+		req := httptest.NewRequest("POST", "/", strings.NewReader(reqBody))
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status OK; got %v", resp.Status)
+		}
+
+		mockHandle.AssertExpectations(t)
+	})
+
+	// Test case where prompt is missing
+	t.Run("WithoutPrompt", func(t *testing.T) {
+		reqBody := `{
+  "model": "gpt-4o",
+  "messages": []
+}`
+		req := httptest.NewRequest("POST", "/", strings.NewReader(reqBody))
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected status 400; got %v", resp.Status)
+		}
+	})
+}

--- a/pkg/llamacpp/handle_test.go
+++ b/pkg/llamacpp/handle_test.go
@@ -31,17 +31,6 @@ func (m *MockHandleFunc) Handle(
 // Setup function to initialize common objects
 func setup() (*MockHandleFunc, []handler.Endpoint) {
 	mockHandle := new(MockHandleFunc)
-	mockHandle.On(
-		"Handle",
-		mock.Anything,
-		mock.MatchedBy(func(slot Slot) bool {
-			return slot.endpointSlot.endpoint == "http://localhost:8080"
-		}),
-		mock.Anything,
-		mock.Anything,
-		mock.Anything,
-	).Return(nil)
-
 	endpoints := []handler.Endpoint{
 		{Endpoint: "http://localhost:8080", Parallel: 1},
 	}
@@ -64,6 +53,19 @@ func TestNewLlamacppHandler(t *testing.T) {
 		req := httptest.NewRequest("POST", "/", strings.NewReader(reqBody))
 		w := httptest.NewRecorder()
 
+		mockHandle.On(
+			"Handle",
+			mock.Anything,
+			mock.MatchedBy(func(slot Slot) bool {
+				return slot.endpointSlot.endpoint == "http://localhost:8080"
+			}),
+			mock.MatchedBy(func(req Request) bool {
+				return req.Prompt == "Hi"
+			}),
+			mock.Anything,
+			mock.Anything,
+		).Return(nil)
+
 		handler.ServeHTTP(w, req)
 
 		resp := w.Result()
@@ -79,6 +81,15 @@ func TestNewLlamacppHandler(t *testing.T) {
 		reqBody := `{}` // Missing prompt
 		req := httptest.NewRequest("POST", "/", strings.NewReader(reqBody))
 		w := httptest.NewRecorder()
+
+		mockHandle.On(
+			"Handle",
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+		).Return(nil)
 
 		handler.ServeHTTP(w, req)
 
@@ -128,6 +139,19 @@ func TestNewLlamacppChatHandler(t *testing.T) {
 		req := httptest.NewRequest("POST", "/", strings.NewReader(reqBody))
 		w := httptest.NewRecorder()
 
+		mockHandle.On(
+			"Handle",
+			mock.Anything,
+			mock.MatchedBy(func(slot Slot) bool {
+				return slot.endpointSlot.endpoint == "http://localhost:8080"
+			}),
+			mock.MatchedBy(func(req Request) bool {
+				return req.Prompt == " [INST] <system> You are a helpful assistant. </system> [/INST] [INST] Hello! [/INST]"
+			}),
+			mock.Anything,
+			mock.Anything,
+		).Return(nil)
+
 		handler.ServeHTTP(w, req)
 
 		resp := w.Result()
@@ -146,6 +170,15 @@ func TestNewLlamacppChatHandler(t *testing.T) {
 }`
 		req := httptest.NewRequest("POST", "/", strings.NewReader(reqBody))
 		w := httptest.NewRecorder()
+
+		mockHandle.On(
+			"Handle",
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+		).Return(nil)
 
 		handler.ServeHTTP(w, req)
 

--- a/pkg/llamacpp/handler.go
+++ b/pkg/llamacpp/handler.go
@@ -19,15 +19,18 @@ func NewLlamacppHandler(
 	lineByLine bool,
 	endpoints []handler.Endpoint,
 ) http.Handler {
-	return newLlamacppHandlerInternal(lineByLine, endpoints, handleLlamacpp)
+	return newLlamacppHandlerInternal(
+		lineByLine,
+		handleLlamacpp,
+		NewQueue(endpoints),
+	)
 }
 
 func newLlamacppHandlerInternal(
 	lineByLine bool,
-	endpoints []handler.Endpoint,
 	handle handleFunc,
+	queue *Queue,
 ) http.Handler {
-	queue := NewQueue(endpoints)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		l := logging.FromContext(ctx).With("function", "handler.<request handler>")
@@ -92,23 +95,22 @@ func NewLlamacppChatHandler(
 	return newLlamacppChatHandlerInternal(
 		logger,
 		lineByLine,
-		endpoints,
 		chatTemplate,
 		stop,
 		handleLlamacpp,
+		NewQueue(endpoints),
 	)
 }
 
 func newLlamacppChatHandlerInternal(
 	logger *slog.Logger,
 	lineByLine bool,
-	endpoints []handler.Endpoint,
 	chatTemplate string,
 	stop []string,
 	handle handleFunc,
+	queue *Queue,
 ) http.Handler {
 	logger.Warn("LlamacppChatHandler is experimental")
-	queue := NewQueue(endpoints)
 	tmpl, err := template.New("chat").Parse(chatTemplate)
 	if err != nil {
 		logger.Error("Error parsing template", err)


### PR DESCRIPTION
This pull request adds unit tests for the `llamacpp` package, specifically targeting the code in `handler.go`. The following changes are included:

- Added unit tests in `llamacpp_test.go` to cover handler functionality with and without prompts.
- Introduced a GitHub workflow to automatically run all tests on each push and pull request. This workflow is configured to run the Go unit tests and is the only test suite currently implemented.
- Made minor changes to `handler.go` to facilitate mocking in the tests. These changes were necessary to enable effective unit testing with mocked dependencies.

**Notes:**
- The unit tests include a failing test to highlight an existing bug in the handler implementation when a prompt is missing.
- The failing test will be addressed in a subsequent bugfix branch.
