### PR TITLE
bugfix: check for missing prompt or messages

### DIFF
--- a/pkg/llamacpp/handle_test.go
+++ b/pkg/llamacpp/handle_test.go
@@ -163,10 +163,33 @@ func TestNewLlamacppChatHandler(t *testing.T) {
 	})
 
 	// Test case where prompt is missing
-	t.Run("WithoutPrompt", func(t *testing.T) {
+	t.Run("WithZeroMessages", func(t *testing.T) {
 		reqBody := `{
   "model": "gpt-4o",
   "messages": []
+}`
+		req := httptest.NewRequest("POST", "/", strings.NewReader(reqBody))
+		w := httptest.NewRecorder()
+
+		mockHandle.On(
+			"Handle",
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+		).Return(nil)
+
+		handler.ServeHTTP(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected status 400; got %v", resp.Status)
+		}
+	})
+	t.Run("WithoutMessages", func(t *testing.T) {
+		reqBody := `{
+  "model": "gpt-4o"
 }`
 		req := httptest.NewRequest("POST", "/", strings.NewReader(reqBody))
 		w := httptest.NewRecorder()

--- a/pkg/llamacpp/handler.go
+++ b/pkg/llamacpp/handler.go
@@ -45,6 +45,11 @@ func newLlamacppHandlerInternal(
 			return
 		}
 
+		if req.Prompt == "" {
+			http.Error(w, "missing prompt", http.StatusBadRequest)
+			return
+		}
+
 		flusher, ok := w.(http.Flusher)
 		if !ok {
 			l.Warn("ResponseWriter does not support Flusher.")
@@ -140,6 +145,11 @@ func newLlamacppChatHandlerInternal(
 		if err != nil {
 			l.Info("Error unmarshaling Body", err)
 			http.Error(w, "error unmarshaling request", http.StatusBadRequest)
+			return
+		}
+
+		if len(chatReq.Messages) == 0 {
+			http.Error(w, "no messages found", http.StatusBadRequest)
 			return
 		}
 


### PR DESCRIPTION
This pull request addresses a bug in the Llamacpp handlers where the absence of a prompt or messages was not properly handled, resulting in incorrect behavior.