### PR TITLE
Respect `ToolChoice` Setting in HandleTools Function

### DIFF
--- a/pkg/llamacpp/handletools.go
+++ b/pkg/llamacpp/handletools.go
@@ -36,7 +36,7 @@ func handleTools(
 	}
 	l.Debug("Found Tools")
 	if chatReq.ToolChoice != "required" {
-		// check if a tool is helpful for the users request, return of not
+		// check if a tool is helpful for the users request, return if not
 		if !checkIfToolHelpful(llama, l, stop, prepareChatPrompt, chatReq.Messages, tools) {
 			l.Debug("Finished Tools: Do NOT use Tool")
 			return false, nil

--- a/pkg/llamacpp/handletools.go
+++ b/pkg/llamacpp/handletools.go
@@ -25,7 +25,7 @@ func handleTools(
 	toolCalls *ExpiringMap,
 	prepareChatPrompt func([]openai.Message) (string, error),
 ) (bool, error) {
-	if len(chatReq.Tools) == 0 {
+	if len(chatReq.Tools) == 0 || chatReq.ToolChoice == "none" {
 		return false, nil
 	}
 	// prepare tool list for prompt, return if no tools
@@ -35,10 +35,12 @@ func handleTools(
 		return false, nil
 	}
 	l.Debug("Found Tools")
-	// check if a tool is helpful for the users request, return of not
-	if !checkIfToolHelpful(llama, l, stop, prepareChatPrompt, chatReq.Messages, tools) {
-		l.Debug("Finished Tools: Do NOT use Tool")
-		return false, nil
+	if chatReq.ToolChoice != "required" {
+		// check if a tool is helpful for the users request, return of not
+		if !checkIfToolHelpful(llama, l, stop, prepareChatPrompt, chatReq.Messages, tools) {
+			l.Debug("Finished Tools: Do NOT use Tool")
+			return false, nil
+		}
 	}
 	l.Debug("Get Tool Call")
 	toolCall, err := generateToolCall(llama, l, stop, prepareChatPrompt, chatReq.Messages, tools)

--- a/pkg/openai/types.go
+++ b/pkg/openai/types.go
@@ -5,6 +5,7 @@ package openai
 type ChatRequest struct {
 	Messages    []Message `json:"messages"`
 	Tools       []Tool    `json:"tools"`
+	ToolChoice  string    `json:"tool_choice"`
 	Model       string    `json:"model"`
 	Stream      bool      `json:"stream"`
 	MaxTokens   int       `json:"max_tokens"`


### PR DESCRIPTION
This PR introduces enhancements to the handleTools function within the `llamacpp` package to respect the `tool_choice` setting in the `ChatRequest` struct.